### PR TITLE
Update buildHTMLReportURL to safely build url

### DIFF
--- a/src/slack/slack-alert.ts
+++ b/src/slack/slack-alert.ts
@@ -16,6 +16,15 @@ const log = pino({
   level: process.env.LOG_LEVEL ? process.env.LOG_LEVEL : "info",
 });
 
+const buildUrl = (...urlComponents: Array<string | undefined>) => {
+  return (
+    urlComponents
+      // Trim leading & trailing slashes
+      .map((component) => String(component).replace(/^\/|\/$/g, ""))
+      .join("/")
+  );
+};
+
 export interface SlackRunnerOptions {
   ciProvider: string;
   vcsRoot: string;
@@ -72,7 +81,6 @@ export const slackRunner = async ({
     const reportHTMLUrl = await buildHTMLReportURL({
       reportDir,
       artefactUrl,
-      ciProvider,
     });
     const videoAttachmentsSlack = await getVideoLinks({
       artefactUrl,
@@ -620,14 +628,12 @@ const getScreenshotLinks = async ({
 const buildHTMLReportURL = async ({
   reportDir,
   artefactUrl,
-  ciProvider,
 }: {
   reportDir: string;
   artefactUrl: string;
-  ciProvider: string;
 }) => {
   const reportHTMLFilename = await getHTMLReportFilename(reportDir);
-  return artefactUrl + reportDir + "/" + reportHTMLFilename;
+  return buildUrl(artefactUrl, reportDir, reportHTMLFilename);
 };
 const getArtefactUrl = async ({
   vcsRoot,

--- a/src/slack/test/slack-alert.test.ts
+++ b/src/slack/test/slack-alert.test.ts
@@ -5,6 +5,7 @@ import "jest";
 import * as path from "path";
 import { testables } from "../slack-alert";
 const {
+  buildHTMLReportURL,
   getScreenshotLinks,
   getVideoLinks,
   prChecker,
@@ -154,6 +155,40 @@ describe("Screenshot Link Checker", () => {
     expect(s).toContain(
       `<http://sometesturl.com${dir}/pnggrad16rgb.png|Screenshot:- pnggrad16rgb.png>`
     );
+  });
+});
+
+describe("HTML report link checker", () => {
+  test("Returns correct url if artefactUrl has no trailing slash", async () => {
+    const REPORT_ARTEFACT_URL: string = "http://sometesturl.com";
+    const dir: string = path.join(__dirname, "reportSingle");
+    const s = await buildHTMLReportURL({
+      reportDir: dir,
+      artefactUrl: REPORT_ARTEFACT_URL,
+    });
+    expect(s).toEqual(
+      `http://sometesturl.com${dir}/report-20190403-233436.html`
+    );
+  });
+  test("Returns correct url if artefactUrl has trailing slash", async () => {
+    const REPORT_ARTEFACT_URL: string = "http://sometesturl.com/";
+    const dir: string = path.join(__dirname, "reportSingle");
+    const s = await buildHTMLReportURL({
+      reportDir: dir,
+      artefactUrl: REPORT_ARTEFACT_URL,
+    });
+    expect(s).toEqual(
+      `http://sometesturl.com${dir}/report-20190403-233436.html`
+    );
+  });
+  test("Returns correct url if reportDir is a relative path", async () => {
+    const REPORT_ARTEFACT_URL: string = "http://sometesturl.com";
+    const dir: string = "reportSingle";
+    const s = await buildHTMLReportURL({
+      reportDir: dir,
+      artefactUrl: REPORT_ARTEFACT_URL,
+    });
+    expect(s).toContain(`http://sometesturl.com/${dir}`);
   });
 });
 


### PR DESCRIPTION
Took a slightly different approach then originally outlined in https://github.com/YOU54F/cypress-slack-reporter/issues/979

Modifying the ciProvider created issues with other functions that also use the artifact url.
https://github.com/YOU54F/cypress-slack-reporter/blob/2c622e1356b2357e3797f99923f1dae2c4e21494/src/slack/slack-alert.ts#L643-L645

Instead, only updated the `buildHTMLReportUrl` function to prevent any downstream implications in other functions.